### PR TITLE
Use sync mode when working with file API

### DIFF
--- a/src/grisp_updater_filesystem.erl
+++ b/src/grisp_updater_filesystem.erl
@@ -47,7 +47,7 @@ storage_prepare(State, Device, Size) when is_binary(Device) ->
     end.
 
 storage_open(State, Device) when is_binary(Device) ->
-    case file:open(Device, [raw, read, write, binary]) of
+    case file:open(Device, [raw, read, write, binary, sync]) of
         {ok, File} -> {ok, File, State};
         {error, _Reason} = Error -> Error
     end;
@@ -79,7 +79,7 @@ storage_terminate(_State, _Reason) ->
 %--- Internal Functions --------------------------------------------------------
 
 truncate_file(Filename, Size) ->
-    case file:open(Filename, [raw, read, write, binary]) of
+    case file:open(Filename, [raw, read, write, binary, sync]) of
         {error, _Reason} = Error -> Error;
         {ok, F} ->
             try file:position(F, {bof, Size}) of


### PR DESCRIPTION
When doing a hardware reset on a device immediately after the software update is finished it might happen that files are corrupted due to data not yet written to disk. The additional `sync` fixes this issue.