### PR TITLE
Do not retry on 4xx http errors

### DIFF
--- a/src/grisp_updater_loader.erl
+++ b/src/grisp_updater_loader.erl
@@ -187,6 +187,12 @@ start_stream(#state{pending = PendMap, streams = StreamMap} = State, Id) ->
             State#state{pending = PendMap2, streams = StreamMap2}
     end.
 
+got_sink_error(State, _StreamRef, Id, {http_error, Code} = Reason)
+  when 400 =< Code, Code < 500 ->
+    % all 4xx http error codes (client errors)
+    % imply that the request should not be repeated
+    grisp_updater_manager:loader_error(Id, Reason),
+    State;
 got_sink_error(#state{pending = PendMap, streams = StreamMap} = State,
                StreamRef, Id, Reason) ->
     %TODO: Figure out which errors are fatal and which are recoverable


### PR DESCRIPTION
This fixes https://github.com/grisp/grisp_updater/issues/3. For testing I removed one of the packages on the server. Before this resulted in an infinite loop of fetching this missing package, now the update fails.

Additionally, I limited the total number of retries per package, to avoid possible further endless loops.