### PR TITLE
Change system API, fix bad truncating of dummy image file and some typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+ - Fix file truncating causing image file in dummy system to be badly
+   truncated [grisp/#10](https://github.com/grisp/grisp_updater/pull/10)
+ - Fix comments and type spec typos [grisp/#10](https://github.com/grisp/grisp_updater/pull/10)
+ 
+### Changed
+
+ - Changed the grisp_updater_system behaviour's system_get_active/1 callback to
+   system_get_systems/1 to add support for software updates from removable
+   media [grisp/#10](https://github.com/grisp/grisp_updater/pull/10)
+ - Pass the target record to grisp_updater_storage behaviour's storage_prepare
+   callback so it can use the target size and total size for boundary checks
+   and file truncating [grisp/#10](https://github.com/grisp/grisp_updater/pull/10)
+
+### Added
+
+ - Add grisp_updater:info/0 to get context-free update information [grisp/#10](https://github.com/grisp/grisp_updater/pull/10)
+ - Add grisp_updater:info/1 to get update information in the context
+   of a specific software update package [grisp/#10](https://github.com/grisp/grisp_updater/pull/10)
+ - Add optional total size field to target record to allow boundary checks and
+   fix file truncating [grisp/#10](https://github.com/grisp/grisp_updater/pull/10)
+ - Add development-time macro USE_UNSEALED_MANIFEST. It makes the update manager
+   retrieve the unsealed MANIFEST file instead of the sealed version
+   MANIFEST.sealed, and do not perform any verification. Used for testing the
+   manifest at development time without having to seal it every time [grisp/#10](https://github.com/grisp/grisp_updater/pull/10)
+
 ## [1.0.0] - 2024-08-07
 
 First release.

--- a/include/grisp_updater.hrl
+++ b/include/grisp_updater.hrl
@@ -4,7 +4,8 @@
 -record(target, {
     device :: binary(),
     offset :: non_neg_integer(),
-    size :: undefined | non_neg_integer()
+    size :: undefined | non_neg_integer(),
+    total :: undefined | non_neg_integer()
 }).
 
 -type target() :: #target{}.

--- a/src/grisp_updater.erl
+++ b/src/grisp_updater.erl
@@ -4,6 +4,7 @@
 %--- Exports -------------------------------------------------------------------
 
 % API functions
+-export([info/0, info/1]).
 -export([update/1, update/2]).
 -export([start/3, start/4]).
 -export([status/0]).
@@ -12,6 +13,12 @@
 
 
 %--- API Functions -------------------------------------------------------------
+
+info() ->
+    grisp_updater_manager:get_info().
+
+info(Url) ->
+    grisp_updater_manager:get_info(Url).
 
 update(Url) ->
     grisp_updater_manager:update(Url, #{}).

--- a/src/grisp_updater_checker.erl
+++ b/src/grisp_updater_checker.erl
@@ -88,7 +88,7 @@ handle_cast({schedule, #block{id = Id} = Block, Target},
             {noreply, State2, timeout(State2)}
     end;
 handle_cast(Request, State) ->
-    ?LOG_WARNING("Unexpected XXXX cast: ~p", [Request]),
+    ?LOG_WARNING("Unexpected cast: ~p", [Request]),
     {noreply, State, timeout(State)}.
 
 handle_info(timeout, #state{pending = M, schedule = Q} = State) ->

--- a/src/grisp_updater_dummy.erl
+++ b/src/grisp_updater_dummy.erl
@@ -12,10 +12,10 @@
 
 %--- Exports -------------------------------------------------------------------
 
-% Behaviour grisp_updater_source callbacks
+% Behaviour grisp_updater_system callbacks
 -export([system_init/1]).
 -export([system_get_global_target/1]).
--export([system_get_active/1]).
+-export([system_get_systems/1]).
 -export([system_prepare_update/2]).
 -export([system_prepare_target/4]).
 -export([system_set_updated/2]).
@@ -26,20 +26,39 @@
 %--- Records -------------------------------------------------------------------
 
 -record(state, {
-    device :: binary()
+    boot :: grisp_updater_system:system_id() | removable,
+    valid :: grisp_updater_system:system_id(),
+    next :: grisp_updater_system:system_id(),
+    device :: binary(),
+    size :: non_neg_integer()
 }).
 
 
 %--- Macros --------------------------------------------------------------------
 
+-define(DEFAULT_BOOT, removable).
+-define(DEFAULT_VALID, 0).
+-define(DEFAULT_NEXT, 0).
 -define(DEFAULT_DEVICE, <<"dummy.img">>).
 -define(DEFAULT_DEVICE_SIZE, ((4 + 256 + 256) * (1024 * 1024))).
 
 
-%--- Behaviour grisp_updater_source Callback -----------------------------------
+%--- Behaviour grisp_updater_system Callback -----------------------------------
 
 system_init(Opts) ->
     ?LOG_INFO("Initializing GRiSP updater's dummy system interface", []),
+    Boot = case maps:find(boot_system, Opts) of
+        {ok, Sys1} when Sys1 =:= removable; Sys1 >= 0, Sys1 =< 1 -> Sys1;
+        error -> ?DEFAULT_BOOT
+    end,
+    Valid = case maps:find(valid_system, Opts) of
+        {ok, Sys2} when Sys2 >= 0, Sys2 =< 1 -> Sys2;
+        error -> ?DEFAULT_VALID
+    end,
+    Next = case maps:find(next_system, Opts) of
+        {ok, Sys3} when Sys3 >= 0, Sys3 =< 1 -> Sys3;
+        error -> ?DEFAULT_NEXT
+    end,
     DeviceFile = case maps:find(device_file, Opts) of
         {ok, F} when is_list(F); is_binary(F) -> F;
         error ->
@@ -50,6 +69,8 @@ system_init(Opts) ->
         {ok, S} when is_integer(S), S > 0 -> S;
         error -> ?DEFAULT_DEVICE_SIZE
     end,
+    State = #state{boot = Boot, valid = Valid, next = Next,
+                   device = DeviceFile, size = DeviceSize},
     ok = filelib:ensure_dir(DeviceFile),
     case file:open(DeviceFile, [raw, write, read]) of
         {error, _Reason} = Error -> Error;
@@ -57,20 +78,20 @@ system_init(Opts) ->
             case file:pread(File, DeviceSize - 1, 1) of
                 {ok, [_]} ->
                     ok = file:close(File),
-                    {ok, #state{device = DeviceFile}};
+                    {ok, State};
                 eof ->
                     ok = file:pwrite(File, DeviceSize - 1, <<0>>),
                     ok = file:close(File),
-                    {ok, #state{device = DeviceFile}};
+                    {ok, State};
                 {error, _Reason} = Error -> Error
         end
     end.
 
-system_get_global_target(#state{device = Device}) ->
-    #target{device = Device, offset = 0, size = undefined}.
+system_get_global_target(#state{device = Device, size = Size}) ->
+    #target{device = Device, offset = 0, size = Size, total = Size}.
 
-system_get_active(_State) ->
-    {0, true}.
+system_get_systems(#state{boot = Boot, valid = Valid, next = Next}) ->
+    {Boot, Valid, Next}.
 
 system_prepare_update(State, 1) ->
     ?LOG_DEBUG("Preparing system 1 for update", []),
@@ -101,5 +122,5 @@ system_validate(State) ->
     {ok, State}.
 
 system_terminate(_State, _Reason) ->
-    ?LOG_INFO("Terminating dummy update system interface", []),
+    ?LOG_INFO("Terminating GRiSP updater's dummy system interface", []),
     ok.

--- a/src/grisp_updater_manifest.erl
+++ b/src/grisp_updater_manifest.erl
@@ -10,6 +10,7 @@
 % API Functions
 -export([parse_data/2]).
 -export([parse_term/2]).
+-export([get_info/1]).
 
 
 %--- API Functions -------------------------------------------------------------
@@ -45,8 +46,22 @@ parse_term(Term, Opts) ->
         throw:Reason -> {error, Reason}
     end.
 
+get_info(#manifest{product = Prod, version = Ver,
+                   desc = Desc, architecture = Arch,
+                   objects = Objects}) ->
+    #{product => Prod, version => Ver,
+      description => Desc, architecture => Arch,
+      objects => [object_info(O) || O <- Objects]}.
+
 
 %--- Internal Functions --------------------------------------------------------
+
+object_info(#object{type = Type, product = Prod, version = Ver, desc = Desc,
+                    block_count = BlockCount, data_size = DataSize,
+                    block_size = BlockSize}) ->
+    #{type => Type, product => Prod, version => Ver, description => Desc,
+      block_count => BlockCount, data_size => DataSize,
+      block_size => BlockSize}.
 
 parse_manifest(Props, Stack, Opts) ->
     Format = check_format(Props, Opts),

--- a/src/grisp_updater_system.erl
+++ b/src/grisp_updater_system.erl
@@ -8,9 +8,8 @@
 %--- Types ---------------------------------------------------------------------
 
 -type system_id() :: non_neg_integer().
--type system_state() :: trial | validated.
 
--export_type([system_id/0, system_state/0]).
+-export_type([system_id/0]).
 
 
 %--- Behaviour Definition ------------------------------------------------------
@@ -19,8 +18,15 @@
     {ok, State :: term()} | {error, term()}.
 -callback system_get_global_target(State :: term()) ->
     GlobalTarget :: target().
--callback system_get_active(State :: term()) ->
-    {SysId :: system_id() | removable, Validated :: boolean() | undefined}.
+-callback system_get_systems(State :: term()) ->
+    {
+        % The system the current software booted from
+        BootSysId :: system_id() | removable,
+        % The system that is currently validated
+        ValidatedSysId :: system_id(),
+        % The system that will boot during next restart
+        NextSysId :: system_id()
+    }.
 -callback system_get_updatable(State :: term()) ->
     {ok, SysId :: system_id(), SystemTarget :: target()} | {error, Reason :: term}.
 -callback system_prepare_update(State :: term(), SysId :: system_id()) ->


### PR DESCRIPTION
     * Change system behaviour callback system_get_active/1 to
       sytem_get_systems/1.
     * Add grisp_updater:info/0 and grisp_updater:info/1 to get some
       information update systems (boot, active and next) and about
       an update manifest.
     * Add optional total size to target, used to calculate file size.
     * Pass the target record to storage preparation to be able
       to properly calculate the minimum size of the target file
       when trunctating.
     * Fix comments and type spec typos.
     * Add development-time macro USE_UNSEALED_MANIFEST. It makes
       the update manager retrieve the unsealed MANIFEST file instead
       of the sealed version MANIFEST.sealed, and do not perform
       any verification. Used for testing the manifest at development
       time without having to seal it every time.